### PR TITLE
Fix python 2/3 compatibilities in rio_tiler.utils.landsat_get_mtl

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,9 @@
 
+0.0.2 (2017-10-17)
+------------------
+- Fix python 2/3 compatibilities in rio_tiler.utils.landsat_get_mtl
+
+
 0.0.1 (2017-10-05)
 ------------------
 - Initial release. Requires Rasterio >= 1.0a10.

--- a/rio_tiler/__init__.py
+++ b/rio_tiler/__init__.py
@@ -1,3 +1,3 @@
 """rio-tiler"""
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -211,7 +211,7 @@ def landsat_get_mtl(sceneid):
     try:
         scene_params = landsat_parse_scene_id(sceneid)
         meta_file = 'http://landsat-pds.s3.amazonaws.com/{}_MTL.txt'.format(scene_params['key'])
-        metadata = urlopen(meta_file).read().decode()
+        metadata = str(urlopen(meta_file).read().decode())
         return toa_utils._parse_mtl_txt(metadata)
     except:
         raise Exception('Could not retrieve {} metadata'.format(sceneid))


### PR DESCRIPTION
closes #2 