### PR TITLE
only read mask when needed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.0a3 (2018-02-05)
+------------------
+- only using `read_masks` for mask creation when it's needed.
+
 1.0a2 (2018-02-05)
 ------------------
 - add "expression" utility function

--- a/rio_tiler/__init__.py
+++ b/rio_tiler/__init__.py
@@ -1,3 +1,3 @@
 """rio-tiler"""
 
-__version__ = '1.0a2'
+__version__ = '1.0a3'

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -162,19 +162,18 @@ def tile_band_worker(address, bounds, tilesize, indexes=[1], nodata=None, alpha=
                                             out_shape=out_shape,
                                             indexes=indexes)
 
-                            mask = vrt.read_masks(1, window=window,
-                                                  out_shape=(tilesize, tilesize),
-                                                  boundless=True,
-                                                  resampling=Resampling.bilinear)
-
                             if nodata is not None:
                                 mask = np.all(data != nodata, axis=0).astype(np.uint8) * 255
-
-                            if alpha is not None:
+                            elif alpha is not None:
                                 mask = vrt.read(alpha, window=window,
                                                 out_shape=(tilesize, tilesize),
                                                 boundless=True,
                                                 resampling=Resampling.bilinear)
+                            else:
+                                mask = vrt.read_masks(1, window=window,
+                                                      out_shape=(tilesize, tilesize),
+                                                      boundless=True,
+                                                      resampling=Resampling.bilinear)
 
     return data, mask
 


### PR DESCRIPTION
closes #25 

This PR change the order for creating mask during tile reading.

using `read_masks` is time/memory consuming. The idea is if, `nodata` or `alpha` option is passed we don't need to use `read_masks`. 