### PR TITLE
Array to image

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+1.0a4 (2018-03-07)
+------------------
+- adds utils.b64_encode_img function to encode an image object into a base64 string
+- add tiles profiles (jpeg, png, webp) based on https://github.com/mapnik/mapnik/wiki/Image-IO#default-output-details
+
+:Breacking Changes:
+- Refactor `rio_tiler.utils.array_to_img` to return PIL image object
+
 1.0a3 (2018-02-05)
 ------------------
 - only using `read_masks` for mask creation when it's needed.

--- a/rio_tiler/__init__.py
+++ b/rio_tiler/__init__.py
@@ -1,3 +1,3 @@
 """rio-tiler"""
 
-__version__ = '1.0a3'
+__version__ = '1.0a4'

--- a/rio_tiler/profiles.py
+++ b/rio_tiler/profiles.py
@@ -3,23 +3,19 @@
 from rio_tiler.errors import InvalidFormat
 
 
-class TileProfiles():
+def get(name):
     """https://github.com/mapnik/mapnik/wiki/Image-IO#default-output-details
     """
-    def __init__(self):
-        pass
+    if name == 'jpeg':
+        """https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg"""
+        return {'quality': 95}
 
-    def get(name):
-        if name == 'jpeg':
-            """https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg"""
-            return {'quality': 95}
+    elif name == 'png':
+        """https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png"""
+        return {'compress_level': 0}
 
-        elif name == 'png':
-            """https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png"""
-            return {'compress_level': 0}
-
-        elif name == 'webp':
-            """https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#webp"""
-            return {'quality': 80}
-        else:
-            raise InvalidFormat('{} format is not supported'.format(name))
+    elif name == 'webp':
+        """https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#webp"""
+        return {'quality': 80}
+    else:
+        raise InvalidFormat('{} format is not supported'.format(name))

--- a/rio_tiler/profiles.py
+++ b/rio_tiler/profiles.py
@@ -1,0 +1,25 @@
+"""rio_tiler.profiles"""
+
+from rio_tiler.errors import InvalidFormat
+
+
+class TileProfiles():
+    """https://github.com/mapnik/mapnik/wiki/Image-IO#default-output-details
+    """
+    def __init__(self):
+        pass
+
+    def get(name):
+        if name == 'jpeg':
+            """https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg"""
+            return {'quality': 95}
+
+        elif name == 'png':
+            """https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png"""
+            return {'compress_level': 0}
+
+        elif name == 'webp':
+            """https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#webp"""
+            return {'quality': 80}
+        else:
+            raise InvalidFormat('{} format is not supported'.format(name))

--- a/rio_tiler/utils.py
+++ b/rio_tiler/utils.py
@@ -18,7 +18,7 @@ from rasterio.enums import Resampling
 from rasterio.plot import reshape_as_image
 from rio_toa import reflectance, brightness_temp, toa_utils
 
-from rio_tiler.profiles import TileProfiles
+from rio_tiler import profiles as TileProfiles
 from rio_tiler.errors import (RioTilerError,
                               InvalidFormat,
                               InvalidLandsatSceneId,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -355,97 +355,88 @@ def test_cbers_id_valid():
     assert utils.cbers_parse_scene_id(scene) == expected_content
 
 
-def test_array_to_img_valid_png():
+def test_array_to_img_valid():
+    """Should work as expected
     """
-    Should work as expected
-    """
-
     arr = np.random.randint(0, 255, size=(3, 512, 512), dtype=np.uint8)
-    tileformat = 'png'
-
-    assert utils.array_to_img(arr, tileformat)
+    assert utils.array_to_img(arr)
 
 
 def test_array_to_img_valid_mask():
+    """Should work as expected
     """
-    Should work as expected
-    """
-
     arr = np.random.randint(0, 255, size=(3, 512, 512), dtype=np.uint8)
     mask = np.random.randint(0, 1, size=(512, 512), dtype=np.uint8) * 255
-    tileformat = 'png'
-
-    assert utils.array_to_img(arr, tileformat, mask=mask)
-
-
-def test_array_to_img_valid_jpg():
-    """
-    Should work as expected
-    """
-
-    arr = np.random.randint(0, 255, size=(3, 512, 512), dtype=np.uint8)
-    tileformat = 'jpg'
-
-    assert utils.array_to_img(arr, tileformat)
+    assert utils.array_to_img(arr, mask=mask)
 
 
 def test_array_to_img_valid_oneband():
+    """Should work as expected
     """
-    Should work as expected
-    """
-
     arr = np.random.randint(0, 255, size=(1, 512, 512), dtype=np.uint8)
     assert utils.array_to_img(arr)
 
 
 def test_array_to_img_valid_noband():
+    """Should work as expected
     """
-    Should work as expected
-    """
-
     arr = np.random.randint(0, 255, size=(512, 512), dtype=np.uint8)
     assert utils.array_to_img(arr)
 
 
 def test_array_to_img_cast():
+    """Should work as expected
     """
-    Should work as expected
-    """
-
     arr = np.random.randint(0, 255, size=(1, 512, 512), dtype=np.int16)
     assert utils.array_to_img(arr)
 
 
 def test_array_to_img_colormap():
+    """Should work as expected
     """
-    Should work as expected
-    """
-
     arr = np.random.randint(0, 255, size=(1, 512, 512), dtype=np.uint8)
-    tileformat = 'png'
-    utils.array_to_img(arr, tileformat, color_map=utils.get_colormap())
+    utils.array_to_img(arr, color_map=utils.get_colormap())
 
 
 def test_array_to_img_bands_colormap():
+    """Should raise an error with invalid format
     """
-    Should raise an error with invalid format
-    """
-
     arr = np.random.randint(0, 255, size=(3, 512, 512), dtype=np.uint8)
-    tileformat = 'png'
     with pytest.raises(InvalidFormat):
-        utils.array_to_img(arr, tileformat, color_map=True)
+        utils.array_to_img(arr, color_map=True)
+
+
+def test_b64_encode_img_valid_jpg():
+    """Should work as expected
+    """
+    arr = np.random.randint(0, 255, size=(4, 512, 512), dtype=np.uint8)
+    img = utils.array_to_img(arr)
+    assert utils.b64_encode_img(img, 'jpeg')
+
+
+def test_b64_encode_img_valid_png():
+    """Should work as expected
+    """
+    arr = np.random.randint(0, 255, size=(4, 512, 512), dtype=np.uint8)
+    img = utils.array_to_img(arr)
+    assert utils.b64_encode_img(img, 'png')
+
+
+def test_b64_encode_img_valid_webp():
+    """Should work as expected
+    """
+    arr = np.random.randint(0, 255, size=(4, 512, 512), dtype=np.uint8)
+    img = utils.array_to_img(arr)
+    assert utils.b64_encode_img(img, 'webp')
 
 
 def test_array_to_img_invalid_format():
+    """Should raise an error with invalid format
     """
-    Should raise an error with invalid format
-    """
-
     arr = np.random.randint(0, 255, size=(1, 512, 512), dtype=np.uint8)
-    tileformat = 'gif'
+    img = utils.array_to_img(arr)
     with pytest.raises(InvalidFormat):
-        utils.array_to_img(arr, tileformat)
+        utils.b64_encode_img(img, 'gif')
 
 
 @patch('rio_tiler.utils.urlopen')


### PR DESCRIPTION
**Breaking Changes**

This PR does:
- refactoring `utils.array_to_img` to return Image object instead of a base64 string 
- adds `utils.b64_encode_img` function to encode an image object into a base64 string
- add tiles profiles (jpeg, png, webp) based on https://github.com/mapnik/mapnik/wiki/Image-IO#default-output-details

