### PR TITLE
README.rst (simplified style)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Rio-tiler
 =========
 
-Rasterio plugin to serve tiles from AWS S3 hosted files.
+Rasterio plugin to create mercator tiles from raster sources.
 
 .. image:: https://circleci.com/gh/mapbox/rio-tiler.svg?style=svg&circle-token=b78bc1a238c21046a855a9c80b441a8f2f9a4478
    :target: https://circleci.com/gh/mapbox/rio-tiler
@@ -10,7 +10,11 @@ Rasterio plugin to serve tiles from AWS S3 hosted files.
 .. image:: https://codecov.io/gh/mapbox/rio-tiler/branch/master/graph/badge.svg?token=zuHupC20cG
    :target: https://codecov.io/gh/mapbox/rio-tiler
 
-Get mercator tile from Landsat, sentinel or other AWS hosted rasters.
+Additional support is provided for the following satellite missions:
+
+* Sentinel 2
+* Landsat 8
+* CBERS
 
 Rio-tiler supports Python 2.7 and 3.3-3.6.
 
@@ -18,12 +22,14 @@ Rio-tiler supports Python 2.7 and 3.3-3.6.
 Install
 =======
 
+You can install rio-tiler using pip
+
 .. code-block:: console
 
     $ pip install -U pip
     $ pip install rio-tiler
 
-Or install from source:
+or install from source:
 
 .. code-block:: console
 
@@ -32,8 +38,7 @@ Or install from source:
     $ pip install -U pip
     $ pip install -e .
 
-
-Or if you want to create an AWS Lambda package using rasterio wheels:
+here is how to create an AWS Lambda package on most UNIX machines:
 
 .. code-block:: console
 
@@ -41,263 +46,78 @@ Or if you want to create an AWS Lambda package using rasterio wheels:
     $ pip install rio-tiler --no-binary numpy -t /tmp/vendored -U
     $ zip -r9q package.zip vendored/*
 
-API Overview
-============
+Overview
+========
 
-rio_tiler.landsat8
-------------------
+Create tiles using one of these rio_tiler modules: :code:`main`, :code:`sentinel2`, :code:`landsat8`, :code:`cbers`.
 
-The ``landsat8`` module processes data hosted on the `Landsat 8 AWS Public Dataset <https://aws.amazon.com/fr/public-datasets/landsat/>`_.
+The :code:`main` module can create mercator tiles from any raster source supported by Rasterio (i.e. local files, http, etc.). The mission specific modules make it easier to extract tiles from AWS S3 buckets (i.e. only a scene ID is required); They can also be used to return metadata.
 
-- **landsat8.bounds**
+All of the tiling modules can return the original image bounds.
 
-    Get WGS84 bounds for a Landsat scene.
+Usage
+=====
 
-    ``Input``:
-      - sceneid: Landsat product id (or scene id for scene < 1st May 2017)
+Get a Sentinel2 tile and its mask (if any).
 
-    ``Output``:
-      - dictionary:
-          - bounds: (minX, minY, maxX, maxY) (list)
-          - sceneid: scene id (string)
+.. code-block:: python
 
-      .. code-block:: python
+   from rio_tiler import sentinel2
+   tile, mask = sentinel2.tile('S2A_tile_20170729_19UDP_0', 77, 89, 8)
+   tile.shape
+   # (3, 256, 256)
 
-          >>> from rio_tiler import landsat8
-          >>> landsat8.bounds('LC08_L1TP_016037_20170813_20170814_01_RT')
-          {'bounds': [-81.30836, 32.10539, -78.82045, 34.22818],
-          'sceneid': 'LC08_L1TP_016037_20170813_20170814_01_RT'}
+Create image from tile
 
-- **landsat8.metadata**
+.. code-block:: python
 
-    Get WGS84 bounds and cumulative histogram cuts for each bands for a Landsat scene.
+   from rio_tiler.utils import array_to_img
+   img = array_to_img(tile, mask=mask) # this returns a pillow image
 
-    ``Input``:
-      - sceneid: Landsat product id (or scene id for scene < 1st May 2017)
-      - pmin: Histogram cut minimum value in percent (default: 2)
-      - pmax: Histogram cut maximum value in percent (default: 98)
+Convert image into base64 encoded string (PNG or JPEG)
 
-    ``Output``:
-      - dictionary:
-          - bounds: (minX, minY, maxX, maxY) (list)
-          - sceneid: scene id (string)
-          - rgbMinMax: Min/Max DN values for the linear rescaling (dictionary)
+.. code-block:: python
 
-        .. code-block:: python
+   from rio_tiler.utils import b64_encode_img
+   str_img = b64_encode_img(img, 'jpeg')
 
-          >>> from rio_tiler import landsat8
-          >>> landsat8.metadata('LC08_L1TP_016037_20170813_20170814_01_RT', pmin=5, pmax=95)
-          {'bounds': [-81.30836, 32.10539, -78.82045, 34.22818],
-           'rgbMinMax': {'1': [1245, 5396],
-            '2': [983, 5384],
-            '3': [718, 5162],
-            '4': [470, 5273],
-            '5': [403, 6440],
-            '6': [258, 4257],
-            '7': [151, 2984]},
-           'sceneid': 'LC08_L1TP_016037_20170813_20170814_01_RT'}
+Get bounds for a Landsat scene (WGS84).
 
-- **landsat8.tile**
+.. code-block:: python
 
-    Return base64 encoded image corresponding to a mercator tile
+   from rio_tiler import landsat8
+   landsat8.bounds('LC08_L1TP_016037_20170813_20170814_01_RT')
+   # {'bounds': [-81.30836, 32.10539, -78.82045, 34.22818], 
+   #  'sceneid': 'LC08_L1TP_016037_20170813_20170814_01_RT'}
 
-    ``Input``:
-      - sceneid : Landsat product id (or scene id for scene < 1st May 2017)
-      - x: Mercator tile X index
-      - y: Mercator tile Y index
-      - z: Mercator tile ZOOM level
-      - rgb: Bands index for the RGB combination (default: (4, 3, 2))
-      - tilesize: Output image size (default: 256)
-      - pan: If True, apply pan-sharpening (default: False)
+Get metadata of a Landsat scene (i.e. percentinle min and max values, and bounds in WGS84) .
 
-    ``Output``:
-      - numpy ndarray of the image data
+.. code-block:: python
 
-      .. code-block:: python
+   from rio_tiler import landsat8
+   landsat8.metadata('LC08_L1TP_016037_20170813_20170814_01_RT', pmin=5, pmax=95)
+   #  {'bounds': [-81.30836, 32.10539, -78.82045, 34.22818],
+   #   'rgbMinMax': {'1': [1245, 5396],
+   #    '2': [983, 5384],
+   #    '3': [718, 5162],
+   #    '4': [470, 5273],
+   #    '5': [403, 6440],
+   #    '6': [258, 4257],
+   #    '7': [151, 2984]},
+   #   'sceneid': 'LC08_L1TP_016037_20170813_20170814_01_RT'}
 
-        >>> from rio_tiler import landsat8
-        >>> tile = landsat8.tile('LC08_L1TP_016037_20170813_20170814_01_RT', 71, 102, 8)
-        >>> tile.shape
-        (3, 256, 256)
+The primary purpose for calculating minimum and maximum values of an image is to rescale pixel values from their original range (e.g. 0 to 65,535) to the range used by computer screens (i.e. 0 and 255) through a linear transformation. This will make images look good on display.
 
+The Datasets
+------------
 
-rio_tiler.sentinel2
--------------------
+* Sentinel2_
+* Landsat8_
+* CBERS_
 
-The ``sentinel2`` module processes data hosted on the `Sentinel 2 AWS Public Dataset <http://sentinel-pds.s3-website.eu-central-1.amazonaws.com>`_.
-
-- **sentinel2.bounds**
-
-    Get WGS84 bounds for a Landsat scene.
-
-    ``Input``:
-      - sceneid: Sentinel scene id (`S2{A|B}_tile_{YYYYMMDD}_{utm_zone}{latitude_band}{grid_square}_{img_number}`)
-
-    ``Output``:
-      - dictionary:
-          - bounds: (minX, minY, maxX, maxY) (list)
-          - sceneid: scene id (string)
-
-    .. code-block:: python
-
-      >>> from rio_tiler import sentinel2
-      >>> sentinel2.bounds('S2A_tile_20170729_19UDP_0')
-      {'bounds': [-70.36082319774495, 47.75776333620836, -68.8677615795376, 48.75301295078041],
-       'sceneid': 'S2A_tile_20170729_19UDP_0'}
-
-- **sentinel2.metadata**
-
-    Get WGS84 bounds and cumulative histogram cuts for each bands for a Sentinel scene.
-
-    ``Input``:
-      - sceneid: Sentinel scene id (`S2{A|B}_tile_{YYYYMMDD}_{utm_zone}{latitude_band}{grid_square}_{img_number}`)
-      - pmin: Histogram cut minimum value in percent (default: 2)
-      - pmax: Histogram cut maximum value in percent (default: 98)
-
-    ``Output``:
-      - dictionary:
-          - bounds: (minX, minY, maxX, maxY) (list)
-          - sceneid: scene id (string)
-          - rgbMinMax: Min/Max DN values for the linear rescaling (dictionary)
-
-    .. code-block:: python
-
-      >>> from rio_tiler import sentinel2
-      >>> sentinel2.metadata('S2A_tile_20170729_19UDP_0', pmin=5, pmax=95)
-      {'sceneid': 'S2A_tile_20170729_19UDP_0',
-      'bounds': [-70.36082319774495, 47.75776333620836, -68.8677615795376, 48.75301295078041],
-      'rgbMinMax': {
-          '01': [1088, 8237],
-          '02': [740, 8288],
-          '03': [488, 7977],
-          '04': [255, 8626],
-          '05': [210, 8877],
-          '06': [172, 9079],
-          '07': [150, 9263],
-          '08': [122, 9163],
-          '8A': [107, 9360],
-          '09': [53, 5926],
-          '10': [6, 546],
-          '11': [15, 5658],
-          '12': [8, 4009]}}
-
-- **sentinel2.tile**
-
-    Return base64 encoded image corresponding to a mercator tile
-
-    ``Input``:
-      - sceneid : Sentinel scene id (`S2{A|B}_tile_{YYYYMMDD}_{utm_zone}{latitude_band}{grid_square}_{img_number}`)
-      - x: Mercator tile X index
-      - y: Mercator tile Y index
-      - z: Mercator tile ZOOM level
-      - rgb: Bands index for the RGB combination (default: (04, 03, 02))
-      - tilesize: Output image size (default: 256)
-
-    ``Output``:
-      - numpy ndarray of the image data
-
-    .. code-block:: python
-
-        >>> from rio_tiler import sentinel2
-        >>> sentinel2.tile('S2A_tile_20170729_19UDP_0', 77, 89, 8, 'png')
-        >>> tile.shape
-        (3, 256, 256)
-
-
-rio_tiler.aws
--------------
-
-The `aws` module can process any raster hosted on AWS S3.
-
-- **aws.bounds**
-
-    Get WGS84 bounds for a scene.
-
-    ``Input``:
-      - bucket: AWS S3 bucket name where the raster is stored
-      - key: AWS S3 key
-
-    ``Output``:
-      - dictionary:
-          - bounds: (minX, minY, maxX, maxY) (list)
-          - bucket: bucket name
-          - key: AWS key
-
-    .. code-block:: python
-
-      >>> from rio_tiler import aws
-      >>> aws.bounds('my-bucket', 'data/my-raster.tif')
-      {'bounds': [-104.77532797841498, 38.95344940972065, -104.77466477631017, 38.95376633047638],
-       'bucket': 'my-bucket'
-       'key': 'data/my-raster.tif'}
-
-- **aws.tile**
-
-    Return base64 encoded image corresponding to a mercator tile
-
-    ``Input``:
-      - bucket: bucket name
-      - key: AWS key
-      - x: Mercator tile X index
-      - y: Mercator tile Y index
-      - z: Mercator tile ZOOM level
-      - rgb: Band index to read (default: (1, 2, 3))
-      - tilesize: Output image size (default: 256)
-
-    ``Output``:
-      - numpy ndarray of the image data
-
-    .. code-block:: python
-
-        >>> from rio_tiler import aws
-        >>> aws.tile('my-bucket', 'data/my-raster.tif', 77, 89, 8)
-        >>> tile.shape
-        (3, 256, 256)
-
-
-Convert ``tile`` output to image
-=================================
-
-rio_tiler.utils.array_to_img
-----------------------------
-
-  ``Input``:
-    - numpy **nuint8** ndarray
-    - mask **nuint8** array
-
-  ``Output``:
-    - Pillow Image object
-
-
-  .. code-block:: python
-
-    >>> from rio_tiler import landsat8
-    >>> from rio_tiler.utils import array_to_img, b64_encode_img
-    >>> tile, mask = landsat8.tile('LC08_L1TP_016037_20170813_20170814_01_RT', 71, 102, 8)
-    >>> # convert the data to an image object
-    >>> img = array_to_img(tile, mask=mask) # this returns a pillow image
-
-
-rio_tiler.utils.b64_encode_img
-------------------------------
-
-  ``Input``:
-    - img Pillow image
-    - tileformat: Image format to return ("jpg" or "png")
-
-  ``Output``:
-    - base64 encoded image PNG or JPEG (string)
-
-
-  .. code-block:: python
-
-    >>> from rio_tiler import landsat8
-    >>> from rio_tiler.utils import array_to_img, b64_encode_img
-    >>> tile, mask = landsat8.tile('LC08_L1TP_016037_20170813_20170814_01_RT', 71, 102, 8)
-    >>> img = array_to_img(tile, mask=mask) # this returns a pillow image
-    >>> str_img = b64_encode_img(img, 'jpeg')
-    'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAEAAElEQVR4AQAggN9/AAAAAAA....
-
+.. _Sentinel2: http://sentinel-pds.s3-website.eu-central-1.amazonaws.com
+.. _Landsat8: https://aws.amazon.com/fr/public-datasets/landsat
+.. _CBERS: https://aws.amazon.com/blogs/publicsector/the-china-brazil-earth-resources-satellite-mission/
 
 License
 -------


### PR DESCRIPTION
This content was originally PR'd as markdown (README.MD). (Apologies Vincent). It has now been reformatted in reStructureText (RST).