### PR TITLE
add Landsat pan band (08) values in histogramm min/max fetch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+Next
+----
+- fetch Landsat panchromatic band min/max (#58)
+
 1.0rc2 (2018-08-22)
 -------------------
 - add test case for pix4d nodata+alpha band data

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,6 @@
 Next
 ----
-- fetch Landsat panchromatic band min/max (#58)
+- add missing Landsat panchromatic band (08) min/max fetch in `rio_tiler.landsat8.metadata` (#58)
 
 1.0rc2 (2018-08-22)
 -------------------

--- a/rio_tiler/landsat8.py
+++ b/rio_tiler/landsat8.py
@@ -70,7 +70,7 @@ def metadata(sceneid, pmin=2, pmax=98):
     info = {'sceneid': sceneid}
     info['bounds'] = toa_utils._get_bounds_from_metadata(meta_data['PRODUCT_METADATA'])
 
-    bands = ['1', '2', '3', '4', '5', '6', '7', '9', '10', '11']
+    bands = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11']
     _min_max_worker = partial(utils.landsat_min_max_worker,
                               address=landsat_address,
                               metadata=meta_data,

--- a/tests/test_landsat.py
+++ b/tests/test_landsat.py
@@ -48,7 +48,7 @@ def test_metadata_valid_default(landsat_get_mtl, monkeypatch):
     meta = landsat8.metadata(LANDSAT_SCENE_C1)
     assert meta.get('sceneid') == 'LC08_L1TP_016037_20170813_20170814_01_RT'
     assert len(meta.get('bounds')) == 4
-    assert meta.get('rgbMinMax')
+    assert len(meta.get('rgbMinMax')) == 11
 
 
 @patch('rio_tiler.utils.landsat_get_mtl')
@@ -64,7 +64,7 @@ def test_metadata_valid_custom(landsat_get_mtl, monkeypatch):
     meta = landsat8.metadata(LANDSAT_SCENE_C1)
     assert meta.get('sceneid') == 'LC08_L1TP_016037_20170813_20170814_01_RT'
     assert len(meta.get('bounds')) == 4
-    assert meta.get('rgbMinMax')
+    assert len(meta.get('rgbMinMax')) == 11
 
 
 @patch('rio_tiler.utils.landsat_get_mtl')


### PR DESCRIPTION
This PR adds Landsat8 Panchromatic min/max fetch when getting Landsat metadata.

cc @sgillies @jacquestardie 